### PR TITLE
Fix build failure on Win64

### DIFF
--- a/lib/ta-lib/make/csr/windows/msbuild/ta_libc/ta_libc.vcxproj
+++ b/lib/ta-lib/make/csr/windows/msbuild/ta_libc/ta_libc.vcxproj
@@ -210,7 +210,7 @@
     <NMakeBuildCommandLine>lib /OUT:.\..\..\..\..\..\lib\ta_libc_$(Configuration).lib .\..\..\..\..\..\lib\ta_abstract_$(Configuration).lib .\..\..\..\..\..\lib\ta_common_$(Configuration).lib .\..\..\..\..\..\lib\ta_func_$(Configuration).lib</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>lib /OUT:.\..\..\..\..\..\lib\ta_libc_$(Configuration).lib .\..\..\..\..\..\lib\ta_abstract_$(Configuration).lib .\..\..\..\..\..\lib\ta_common_$(Configuration).lib .\..\..\..\..\..\lib\ta_func_$(Configuration).lib</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>del .\..\..\..\..\..\lib\ta_libc_$(Configuration).lib</NMakeCleanCommandLine>
-    <NMakeOutput> .\..\..\..\..\..\lib\ta_libc_$(Configuration).lib</NMakeOutput>
+    <NMakeOutput>.\..\..\..\..\..\lib\ta_libc_$(Configuration).lib</NMakeOutput>
     <TargetExt>.lib</TargetExt>
     <IntDir>.\..\..\..\..\..\temp\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>.\..\..\..\..\..\lib\</OutDir>


### PR DESCRIPTION
Somehow there was an extra space causing the build to fail on Win64:

```
  C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.MakeFile.Targets(22,5): error MSB4184: The expression
 "[System.IO.Path]::GetDirectoryName(S:\Projects\forex.analytics\lib\ta-lib\make\csr\windows\msbuild\ta_libc\ .\..\..\..
\..\..\lib\ta_libc_csr.lib)" cannot be evaluated. The path is not of a legal form. [S:\Projects\forex.analytics\lib\ta-l
ib\make\csr\windows\msbuild\ta_libc\ta_libc.vcxproj]

    8 Warning(s)
    1 Error(s)
```